### PR TITLE
fix required request properties

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -298,7 +298,7 @@ func (p *Parser) ParseActions(res map[string]Resource) (map[string][]Action, err
 			if e.Schema != nil {
 				var flds []*Property
 				for name, tp := range e.Schema.Properties {
-					fld, err := NewProperty(name, tp, df, p.schema)
+					fld, err := NewProperty(name, tp, e.Schema, p.schema)
 					if err != nil {
 						return nil, errors.Wrapf(err, "failed to parse %s", id)
 					}


### PR DESCRIPTION
using Link.Schema instead of top level definitions when parsing actions


