### PR TITLE
Mention goimports in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ prmd style JSON Hyper Schema to Go structs, and validators
 
 ## Why created
 
+## Prerequisite
+
+```
+go get -u golang.org/x/tools/cmd/goimports
+```
+
+`prmdg` applies `goimports` to the ourput file.
+
 ## Installation
 
 ```


### PR DESCRIPTION
```
prmdg: error: failed to goimports: exec: "goimports": executable file not found in $PATH
prmdg: error: failed to goimports: exec: "goimports": executable file not found in $PATH
```